### PR TITLE
Clean up comments and fix typos

### DIFF
--- a/Itemex/convert_sqlite_to_mysql.py
+++ b/Itemex/convert_sqlite_to_mysql.py
@@ -7,7 +7,7 @@ import sqlite3
 import pymysql
 
 def create_tables_in_mariadb(maria_cursor):
-    # Create table statements für MariaDB
+    # Create table statements for MariaDB
     tables = {
         "SELLORDERS": """
             CREATE TABLE IF NOT EXISTS SELLORDERS (
@@ -74,25 +74,25 @@ def create_tables_in_mariadb(maria_cursor):
         maria_cursor.execute(statement)
 
 def transfer_data(sqlite_db_file, maria_db_config):
-    # Verbindung zu SQLite
+    # Connect to SQLite
     sqlite_conn = sqlite3.connect(sqlite_db_file)
     sqlite_cursor = sqlite_conn.cursor()
 
-    # Verbindung zu MariaDB
+    # Connect to MariaDB
     maria_conn = pymysql.connect(**maria_db_config)
     maria_cursor = maria_conn.cursor()
 
-    # Tabellen in MariaDB erstellen, falls sie nicht existieren
+    # Create tables in MariaDB if they do not exist
     create_tables_in_mariadb(maria_cursor)
 
-    # Liste der Tabellen
+    # List of tables
     table_names = [
         "SELLORDERS", "BUYORDERS", "FULFILLEDORDERS", "PAYOUTS",
         "SETTINGS", "SELL_NOTIFICATION"
     ]
 
     for table in table_names:
-        # Daten von SQLite abrufen
+        # Fetch data from SQLite
         sqlite_cursor.execute(f"SELECT * FROM {table}")
         rows = sqlite_cursor.fetchall()
 
@@ -116,18 +116,18 @@ def transfer_data(sqlite_db_file, maria_db_config):
                     print(f"Error inserting data into table {table}, data: {row}. Error: {e}")
 
 
-    # Verbindungen schließen
+    # Close connections
     sqlite_cursor.close()
     sqlite_conn.close()
     maria_cursor.close()
     maria_conn.close()
 
 if __name__ == "__main__":
-    SQLITE_DB_FILE = 'itemex.db'                    # if this program isn't in the same folder, you have to use the full path
+    SQLITE_DB_FILE = 'itemex.db'                    # if this program isn't in the same folder, use the full path
     MARIA_DB_CONFIG = {
-        'host': 'localhost',                        # ip address or domain of your MariaDB or MySQL server
+        'host': 'localhost',                        # IP address or domain of your MariaDB or MySQL server
         'user': 'root',         
         'password': 'password',
-        'db': 'itemex_db'                           # name of the database ( you have to create in manually )
+        'db': 'itemex_db'                           # name of the database (you have to create it manually)
     }
     transfer_data(SQLITE_DB_FILE, MARIA_DB_CONFIG)

--- a/Itemex/pom.xml
+++ b/Itemex/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>sh.ome</groupId>
   <artifactId>itemex</artifactId>
-  <version>0.21.5</version>
+  <version>0.22.2</version>
   <packaging>jar</packaging>
 
   <name>Itemex</name>
@@ -86,7 +86,7 @@
     <dependency>
       <groupId>org.mariadb.jdbc</groupId>
       <artifactId>mariadb-java-client</artifactId>
-      <version>2.7.3</version>  <!-- Aktuelle Version ersetzen -->
+      <version>2.7.3</version>  <!-- Use the latest version -->
     </dependency>
 
 

--- a/Itemex/src/main/java/sh/ome/itemex/Itemex.java
+++ b/Itemex/src/main/java/sh/ome/itemex/Itemex.java
@@ -49,8 +49,8 @@ import sh.ome.itemex.events.SignShop;
 import sh.ome.itemex.events.i_ClickGUI;
 import sh.ome.itemex.files.CategoryFile;
 import sh.ome.itemex.commands.ix_command;
-import sh.ome.itemex.functions.i_autocompletation;
-import sh.ome.itemex.functions.ix_autocompletation;
+import sh.ome.itemex.functions.i_autocompletion;
+import sh.ome.itemex.functions.ix_autocompletion;
 import sh.ome.itemex.functions.sqliteDb;
 import sh.ome.itemex.shedule.DataDifferenceSender;
 import sh.ome.itemex.shedule.Metrics;
@@ -151,9 +151,9 @@ public final class Itemex extends JavaPlugin implements Listener {
         getLogger().info("\n\n");
 
         getCommand("ix").setExecutor(new ix_command());
-        getCommand("ix").setTabCompleter(new ix_autocompletation());
+        getCommand("ix").setTabCompleter(new ix_autocompletion());
         getCommand("i").setExecutor(new i_command());
-        getCommand("i").setTabCompleter(new i_autocompletation());
+        getCommand("i").setTabCompleter(new i_autocompletion());
 
         getServer().getPluginManager().registerEvents(new PlayerJoin(), this);
         getServer().getPluginManager().registerEvents(new ix_ClickGUI(), this);

--- a/Itemex/src/main/java/sh/ome/itemex/files/CategoryFile.java
+++ b/Itemex/src/main/java/sh/ome/itemex/files/CategoryFile.java
@@ -54,7 +54,7 @@ public class CategoryFile {
     }
 
 
-    public void seDetault() {
+    public void setDefault() {
         //file_config.setDefaults("Test:", "Test");
     }
 

--- a/Itemex/src/main/java/sh/ome/itemex/functions/i_autocompletion.java
+++ b/Itemex/src/main/java/sh/ome/itemex/functions/i_autocompletion.java
@@ -8,7 +8,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-public class i_autocompletation implements TabCompleter {
+public class i_autocompletion implements TabCompleter {
     @Override
     public List<String> onTabComplete(CommandSender sender, Command command, String label, String[] args) {
 

--- a/Itemex/src/main/java/sh/ome/itemex/functions/ix_autocompletion.java
+++ b/Itemex/src/main/java/sh/ome/itemex/functions/ix_autocompletion.java
@@ -18,7 +18,7 @@ import java.util.List;
 import static sh.ome.itemex.commands.commands.*;
 import static sh.ome.itemex.functions.sqliteDb.getPayout;
 
-public class ix_autocompletation implements TabCompleter {
+public class ix_autocompletion implements TabCompleter {
 
     private static final int MAX_BUFFER = 1000000000;
 

--- a/Itemex/src/main/java/sh/ome/itemex/shedule/DataDifferenceSender.java
+++ b/Itemex/src/main/java/sh/ome/itemex/shedule/DataDifferenceSender.java
@@ -6,7 +6,6 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.Statement;
@@ -41,26 +40,26 @@ public class DataDifferenceSender {
                 URL url = new URL(Itemex.server_url + "/itemex");
                 HttpURLConnection con = (HttpURLConnection) url.openConnection();
 
-                // Timeout festlegen
-                con.setConnectTimeout(5000); // 5 Sekunden Timeout für den Verbindungsaufbau
-                con.setReadTimeout(5000);    // 5 Sekunden Timeout für das Lesen von Daten
+                // Set connection timeouts
+                con.setConnectTimeout(5000); // 5 second timeout for the connection setup
+                con.setReadTimeout(5000);    // 5 second timeout for reading data
 
                 con.setRequestMethod("POST");
                 con.setRequestProperty("Content-Type", "application/json");
                 con.setDoOutput(true);
 
-                // Karte erstellen, um Zähler und ID zu speichern
+                // Create a map to store counters and the ID
                 Map<String, Object> data = new HashMap<>();
                 data.put("jwt_token", Itemex.jwt_token);
                 data.put("latest_ids", getLatestIdsString());
 
-                // Karte in JSON-String konvertieren und in den Ausgabestrom schreiben
+                // Convert map to JSON string and write it to the output stream
                 String json = new Gson().toJson(data);
                 try (OutputStream os = con.getOutputStream()) {
                     os.write(json.getBytes(StandardCharsets.UTF_8));
                 }
 
-                // Antwortcode überprüfen und Verbindung schließen
+                // Check response code and close connection
                 int responseCode = con.getResponseCode();
 
                 if (responseCode == HttpURLConnection.HTTP_OK) {
@@ -138,7 +137,7 @@ public class DataDifferenceSender {
             String[] serverIds = responseIds.split(":");
 
             if (latestIds.length != serverIds.length) {
-                System.err.println("Ungültige Serverantwort!");
+                System.err.println("Invalid server response!");
                 return;
             }
 
@@ -213,26 +212,26 @@ public class DataDifferenceSender {
                 URL url = new URL(Itemex.server_url + "/itemex/");
                 HttpURLConnection con = (HttpURLConnection) url.openConnection();
 
-                // Timeout festlegen
-                con.setConnectTimeout(15000); // 15 Sekunden Timeout für den Verbindungsaufbau
-                con.setReadTimeout(15000);    // 15 Sekunden Timeout für das Lesen von Daten
+                // Set connection timeouts
+                con.setConnectTimeout(15000); // 15 second timeout for the connection setup
+                con.setReadTimeout(15000);    // 15 second timeout for reading data
 
                 con.setRequestMethod("POST");
                 con.setRequestProperty("Content-Type", "application/json");
                 con.setDoOutput(true);
 
-                // Karte erstellen und das eingegebene JSON einfügen
+                // Create payload and insert the provided JSON
                 Map<String, Object> payload = new HashMap<>();
                 payload.put("jwt_token", Itemex.jwt_token);
                 payload.put("data", new Gson().fromJson(inputJson, Object.class));
 
-                // Karte in JSON-String konvertieren und in den Ausgabestrom schreiben
+                // Convert map to JSON string and write it to the output stream
                 String jsonPayload = new Gson().toJson(payload);
                 try (OutputStream os = con.getOutputStream()) {
                     os.write(jsonPayload.getBytes(StandardCharsets.UTF_8));
                 }
 
-                // Antwortcode überprüfen und Verbindung schließen
+                // Check response code and close connection
                 int responseCode = con.getResponseCode();
 
                 if (responseCode == HttpURLConnection.HTTP_OK) {

--- a/Itemex/src/main/resources/config.yml
+++ b/Itemex/src/main/resources/config.yml
@@ -11,7 +11,7 @@ db_port: 3306
 db_username: itemex
 db_passwd: Str0ngP&&7w0rt
 
-# The Admin function creates a buy- and sellorder each item with a spread (gab between buy- and sellorder) of 100% by default. You can edit this
+# The Admin function creates a buy- and sell order for each item with a spread (gap between buy and sell order) of 100% by default. You can edit this
 # variable by editing "admin_function_percentage".
 admin_function: false
 admin_function_spread_percentage: 100.0
@@ -19,7 +19,7 @@ admin_function_spread_percentage: 100.0
 # If a order will be fulfilled with the admin order, the order will be recreated with an adjusted price by that percentage value (sellorder = increase price; buyorder = decrease price)
 admin_function_price_change_percentage: 10
 
-# If there is no buy limit or sell limit order at an item, Itemex use this value for initial admin-sellorder-price and adds admin_function_percentage (default 100) to the admin-buyorder-price.
+# If there is no buy limit or sell limit order for an item, Itemex uses this value for the initial admin sell order price and adds admin_function_percentage (default 100) to the admin buy order price.
 admin_function_initial_last_price: 100
 
 # currency representation
@@ -51,7 +51,7 @@ pre_release: true
 # If this option is enabled you will get access to our Itemex Web Interface (will work like luckperms editor)
 webui: true
 
-# This notificate the player on every start, how much he sold
+# This notifies the player on every start how much they sold
 sales_notification: true
 
 # Turn on the chestshop feature

--- a/Itemex/src/main/resources/plugin.yml
+++ b/Itemex/src/main/resources/plugin.yml
@@ -32,8 +32,8 @@ permissions:
     description: list or withdraw all your available payouts
     default: true
   itemex.command.ix.deposit:
-      description: deposit items from your inventory
-      default: true
+    description: deposit items from your inventory
+    default: true
   itemex.command.ix.order.list:
     description: list all own buy- and sellorders
     default: true


### PR DESCRIPTION
## Summary
- correct various typos in configuration comments and plugin manifest
- fix class names `i_autocompletion` and `ix_autocompletion`
- update english comments and remove unused import
- adjust example database script comments
- synchronize version in pom.xml

## Testing
- `python3 -m py_compile Itemex/convert_sqlite_to_mysql.py`
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685435a8fb40832ab7dbe953d4ee8298