### PR TITLE
Add minimal REST API for Itemex

### DIFF
--- a/Itemex/src/main/java/sh/ome/itemex/Itemex.java
+++ b/Itemex/src/main/java/sh/ome/itemex/Itemex.java
@@ -89,6 +89,8 @@ public final class Itemex extends JavaPlugin implements Listener {
     public static char decimal_separator;
     public static char thousand_separator;
     public static String unitLocation;
+    public static boolean webui;
+    public static int web_port;
     public static boolean chestshop;
     public static double broker_fee_buyer;
     public static double broker_fee_seller;
@@ -208,6 +210,9 @@ public final class Itemex extends JavaPlugin implements Listener {
         this.decimal_separator = config.getString("decimal_separator").charAt(0);
         this.thousand_separator = config.getString("thousand_separator").charAt(0);
         this.unitLocation = config.getString("unitLocation");
+
+        this.webui = config.getBoolean("webui");
+        this.web_port = config.getInt("web_port", 8080);
 
 
 
@@ -362,6 +367,15 @@ public final class Itemex extends JavaPlugin implements Listener {
                 DataDifferenceSender.sendDataDifferencesToServer();
             }, 200, 288000); //20 == 1 second -> 288000 = 4h
         }
+        if(webui) {
+            try {
+                sh.ome.itemex.web.WebServer.startServer(web_port);
+                getLogger().info("Web UI started on port " + web_port);
+            } catch (IOException e) {
+                getLogger().warning("Failed to start Web UI");
+            }
+        }
+
 
 
 
@@ -390,6 +404,9 @@ public final class Itemex extends JavaPlugin implements Listener {
     public void onDisable() {
         if(itemex_stats) { //itemex_stats
             checkAndSendUsageCounts();
+        }
+        if(webui) {
+            sh.ome.itemex.web.WebServer.stopServer();
         }
         mtop = null;
         System.gc(); // Suggest JVM to run garbage collection

--- a/Itemex/src/main/java/sh/ome/itemex/web/WebServer.java
+++ b/Itemex/src/main/java/sh/ome/itemex/web/WebServer.java
@@ -1,0 +1,57 @@
+package sh.ome.itemex.web;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+
+/**
+ * Simple HTTP server exposing a very small REST API for Itemex.
+ */
+public class WebServer {
+    private static HttpServer server;
+
+    /**
+     * Starts the HTTP server on the given port.
+     */
+    public static void startServer(int port) throws IOException {
+        server = HttpServer.create(new InetSocketAddress(port), 0);
+        server.createContext("/", new RootHandler());
+        server.createContext("/health", new HealthHandler());
+        server.setExecutor(null); // creates a default executor
+        server.start();
+    }
+
+    /** Stop the server if it is running. */
+    public static void stopServer() {
+        if (server != null) {
+            server.stop(0);
+            server = null;
+        }
+    }
+
+    private static class RootHandler implements HttpHandler {
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            String response = "Itemex Web API";
+            exchange.sendResponseHeaders(200, response.getBytes().length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(response.getBytes());
+            }
+        }
+    }
+
+    private static class HealthHandler implements HttpHandler {
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            String response = "{\"status\":\"ok\",\"version\":\"" + sh.ome.itemex.Itemex.version + "\"}";
+            exchange.getResponseHeaders().set("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, response.getBytes().length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(response.getBytes());
+            }
+        }
+    }
+}

--- a/Itemex/src/main/resources/config.yml
+++ b/Itemex/src/main/resources/config.yml
@@ -50,6 +50,7 @@ pre_release: true
 
 # If this option is enabled you will get access to our Itemex Web Interface (will work like luckperms editor)
 webui: true
+web_port: 8080
 
 # This notifies the player on every start how much they sold
 sales_notification: true

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Edit `plugins/Itemex/config.yml` to configure language, database type (SQLite or
 ```yaml
 lang: en
 # database_type: sqlite or mariadb
+webui: true
+web_port: 8080
 ```
 
 Restart the server after changing the config.


### PR DESCRIPTION
## Summary
- add simple built-in `WebServer` using `HttpServer`
- start web server on plugin enable and stop on disable
- expose configuration options `webui` and `web_port`
- document new settings in README

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854604290c8832aaf2a31f7c295c672