### PR TITLE
Add aliases for whatIsInMyRightHand command

### DIFF
--- a/Itemex/src/main/java/sh/ome/itemex/commands/commands.java
+++ b/Itemex/src/main/java/sh/ome/itemex/commands/commands.java
@@ -551,7 +551,7 @@ public class commands {
                 "\n" + white + "/ix " + light_purple + "order list " + white + "<buyordery | sellorders> *<item id>" + dark_gray + "| " + Itemex.language.getString("help_order_list") +
                 "\n" + white + "/ix " + light_purple + "order close " + white + "<buyordery | sellorders> <order id> " + dark_gray + "| " + Itemex.language.getString("help_order_close") +
 
-                "\n" + white + "/ix " + dark_aqua + "whatIsInMyRightHand" + dark_gray+ "| " + Itemex.language.getString("help_wiimrh") +
+                "\n" + white + "/ix " + dark_aqua + "whatIsInMyRightHand|righthand|rh" + dark_gray+ "| " + Itemex.language.getString("help_wiimrh") +
 
                 "\n" + white + "/ix " + gold + "withdraw list " + dark_gray+ "| " + Itemex.language.getString("help_with_list") +
                 "\n" + white + "/ix " + gold + "withdraw" + white + " <itemname> <amount> " + dark_gray + "| " + Itemex.language.getString("help_withdraw") + dark_purple +

--- a/Itemex/src/main/java/sh/ome/itemex/commands/ix_command.java
+++ b/Itemex/src/main/java/sh/ome/itemex/commands/ix_command.java
@@ -752,7 +752,9 @@ public class ix_command implements CommandExecutor {
 
 
 
-                else if (strings[0].equals("whatIsInMyRightHand")) {
+                else if (strings[0].equalsIgnoreCase("whatIsInMyRightHand") ||
+                        strings[0].equalsIgnoreCase("righthand") ||
+                        strings[0].equalsIgnoreCase("rh")) {
 
                     if (!p.hasPermission("itemex.command.ix.whatIsInMyRightHand")) {
                         p.sendMessage(ChatColor.RED + Itemex.language.getString("message_no_permission"));

--- a/Itemex/src/main/java/sh/ome/itemex/functions/ix_autocompletion.java
+++ b/Itemex/src/main/java/sh/ome/itemex/functions/ix_autocompletion.java
@@ -29,7 +29,7 @@ public class ix_autocompletion implements TabCompleter {
             if (args.length == 1) {
                 String input = args[0].toLowerCase();
                 List<String> options;
-                options = Arrays.asList("price", "buy", "sell", "stats", "whatIsInMyRightHand", "withdraw", "deposit", "gui", "order", "setting", "send");
+                options = Arrays.asList("price", "buy", "sell", "stats", "whatIsInMyRightHand", "righthand", "rh", "withdraw", "deposit", "gui", "order", "setting", "send");
                 List<String> filteredOptions = new ArrayList<>();
                 for (String option : options) {
                     if (option.startsWith(input))
@@ -354,7 +354,9 @@ public class ix_autocompletion implements TabCompleter {
 
             else if(args[0].equals("gui"))
                 return Arrays.asList("");
-            else if(args[0].equals("whatIsInMyRightHand"))
+            else if(args[0].equalsIgnoreCase("whatIsInMyRightHand") ||
+                    args[0].equalsIgnoreCase("righthand") ||
+                    args[0].equalsIgnoreCase("rh"))
                 return Arrays.asList("");
 
         }

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,3 +3,7 @@
 ## [0.1.0] - Initial creation of agent instructions and changelog
 - Added `agent.md` with instructions on changelog usage and semantic versioning.
 - Created `changelog.txt`.
+
+## [0.2.0] - Added case-insensitive alias for /ix whatIsInMyRightHand
+- Command now accepts `whatIsInMyRightHand`, `righthand` and `rh` in any case.
+- Updated help text and autocompletion to include new aliases.


### PR DESCRIPTION
## Summary
- make `whatIsInMyRightHand` command case-insensitive
- add `righthand` and `rh` aliases
- update autocompletion and help text
- document change in `changelog.txt`

## Testing
- `mvn -q -f Itemex/pom.xml test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685464589f5c832aa243dd369b746d8f