### PR TITLE
Fix unlist duplication exploit

### DIFF
--- a/Itemex/src/main/java/sh/ome/itemex/events/ClickGUI.java
+++ b/Itemex/src/main/java/sh/ome/itemex/events/ClickGUI.java
@@ -214,11 +214,11 @@ public class ClickGUI implements Listener {
                                 }
                             }
 
-                            if(is_lore)
+                            if(is_lore) {
                                 sqliteDb.PlayercloseOrder(p.getUniqueId().toString(), buy_or_sell, Integer.parseInt(orderID));
-
-                            //e.getView().close();
-                            //return;
+                                e.getView().close();
+                                return;
+                            }
                         }
 
                         else if(menu_type.contains("Vault")) {

--- a/Itemex/src/main/java/sh/ome/itemex/events/i_ClickGUI.java
+++ b/Itemex/src/main/java/sh/ome/itemex/events/i_ClickGUI.java
@@ -201,11 +201,11 @@ public class i_ClickGUI implements Listener {
                                 }
                             }
 
-                            if (is_lore)
+                            if (is_lore) {
                                 sqliteDb.PlayercloseOrder(p.getUniqueId().toString(), buy_or_sell, Integer.parseInt(orderID));
-
-                            //e.getView().close();
-                            //return;
+                                e.getView().close();
+                                return;
+                            }
                         } else if (menu_type.contains("Vault")) {
                             ItemStack item = e.getCurrentItem();
                             if (item == null)

--- a/Itemex/src/main/java/sh/ome/itemex/events/ix_ClickGUI.java
+++ b/Itemex/src/main/java/sh/ome/itemex/events/ix_ClickGUI.java
@@ -205,11 +205,11 @@ public class ix_ClickGUI implements Listener {
                                 }
                             }
 
-                            if (is_lore)
+                            if (is_lore) {
                                 sqliteDb.PlayercloseOrder(p.getUniqueId().toString(), buy_or_sell, Integer.parseInt(orderID));
-
-                            //e.getView().close();
-                            //return;
+                                e.getView().close();
+                                return;
+                            }
                         } else if (menu_type.contains("Vault")) {
                             ItemStack item = e.getCurrentItem();
                             if (item == null)

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,3 +3,6 @@
 ## [0.1.0] - Initial creation of agent instructions and changelog
 - Added `agent.md` with instructions on changelog usage and semantic versioning.
 - Created `changelog.txt`.
+
+## [0.1.1] - Fix order unlisting dup bug
+- Closed the GUI after unlisting an order to prevent duplicate item payouts.


### PR DESCRIPTION
## Summary
- close the Order Book GUI after an order is unlisted
- document fix in `changelog.txt`

## Testing
- `mvn -q -DskipTests package` *(fails: no tests)*

------
https://chatgpt.com/codex/tasks/task_e_685464a369c4832a9511bc1ebd9493d8