### PR TITLE
Improve security for order blocking

### DIFF
--- a/Itemex/pom.xml
+++ b/Itemex/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>sh.ome</groupId>
   <artifactId>itemex</artifactId>
-  <version>0.22.3</version>
+  <version>0.22.4</version>
   <packaging>jar</packaging>
 
   <name>Itemex</name>

--- a/Itemex/src/main/java/sh/ome/itemex/Itemex.java
+++ b/Itemex/src/main/java/sh/ome/itemex/Itemex.java
@@ -70,7 +70,7 @@ public final class Itemex extends JavaPlugin implements Listener {
 
     private static Itemex plugin;
     public static Economy econ = null;
-    public static String version = "0.22.3";
+    public static String version = "0.22.4";
     public static String lang;
     public static String database_type;
     public static String db_name;

--- a/Itemex/src/main/java/sh/ome/itemex/functions/sqliteDb.java
+++ b/Itemex/src/main/java/sh/ome/itemex/functions/sqliteDb.java
@@ -909,10 +909,13 @@ public class sqliteDb {
 
 
     public static boolean blockOrder(String table_name, int ID) {
-        //getLogger().info("# DEBUG - blockOrder");
-        Statement stmt = null;
+        // Only allow known table names to avoid SQL injection
+        if (!"SELLORDERS".equals(table_name) && !"BUYORDERS".equals(table_name)) {
+            return false;
+        }
+        PreparedStatement pstmt = null;
         int update_status = 0;
-        String sql;
+        String sql = "UPDATE " + table_name + " SET amount = 0 WHERE id = ?";
 
         if (Itemex.c == null) {
             Itemex.c = createDatabase.createConnection();
@@ -921,19 +924,18 @@ public class sqliteDb {
 
         if (Itemex.c != null) {
             try {
-                stmt = Itemex.c.createStatement();
-                sql = "UPDATE " + table_name + " SET amount = 0 WHERE id = " + ID;
-
-                update_status = stmt.executeUpdate(sql);
+                pstmt = Itemex.c.prepareStatement(sql);
+                pstmt.setInt(1, ID);
+                update_status = pstmt.executeUpdate();
 
             } catch ( Exception e ) {
                 System.err.println( e.getClass().getName() + ": " + e.getMessage() );
 
                 return false;
             } finally {
-                if (stmt != null) {
+                if (pstmt != null) {
                     try {
-                        stmt.close();
+                        pstmt.close();
                     } catch (SQLException e) {
                         e.printStackTrace();
                     }

--- a/Itemex/src/main/resources/config.yml
+++ b/Itemex/src/main/resources/config.yml
@@ -9,7 +9,7 @@ db_name: itemex_db
 db_hostname: localhost
 db_port: 3306
 db_username: itemex
-db_passwd: Str0ngP&&7w0rt
+db_passwd: CHANGEME
 
 # The Admin function creates a buy- and sell order for each item with a spread (gap between buy and sell order) of 100% by default. You can edit this
 # variable by editing "admin_function_percentage".

--- a/changelog.txt
+++ b/changelog.txt
@@ -10,3 +10,9 @@
 ## [0.2.0] - Added case-insensitive alias for /ix whatIsInMyRightHand
 - Command now accepts `whatIsInMyRightHand`, `righthand` and `rh` in any case.
 - Updated help text and autocompletion to include new aliases.
+
+
+## [0.2.1] - Security and stability fixes
+- Sanitized table name and used prepared statements in `blockOrder` to prevent SQL injection.
+- Replaced default database password in `config.yml` with placeholder.
+


### PR DESCRIPTION
## Summary
- sanitize table names in database order blocking
- replace example DB password with placeholder
- update plugin version to 0.22.4
- document changes in changelog

## Testing
- `mvn clean package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685466903e78832a8465158d7d0b0c2d