### PR TITLE
Graceful update server handling

### DIFF
--- a/Itemex/src/main/java/sh/ome/itemex/shedule/UpdateItemex.java
+++ b/Itemex/src/main/java/sh/ome/itemex/shedule/UpdateItemex.java
@@ -36,10 +36,15 @@ public class UpdateItemex {
 
 
         try {
-            server_version = new Scanner( url.openStream() ).useDelimiter("\\A").next();
+            server_version = new Scanner(url.openStream()).useDelimiter("\\A").next();
+        } catch (Exception e) {
+            getLogger().warning("Unable to reach update server: " + e.getMessage());
+            return; // graceful handling if server unavailable
         }
-        catch (Exception e){
-            getLogger().info("Exception: " + e);
+
+        if(server_version == null || server_version.isEmpty()) {
+            getLogger().warning("Update server returned no version information.");
+            return;
         }
 
         // if version on server is newer

--- a/changelog.txt
+++ b/changelog.txt
@@ -19,3 +19,6 @@
 ## [0.2.1] - Security and stability fixes
 - Sanitized table name and used prepared statements in `blockOrder` to prevent SQL injection.
 - Replaced default database password in `config.yml` with placeholder.
+
+## [0.2.2] - Robust update checks
+- Update process now handles unreachable update server gracefully, avoiding runtime errors.


### PR DESCRIPTION
## Summary
- prevent crashes when the update server is unreachable
- document the improvement in the changelog

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68548db308fc832aac0b54f75aabd9a3