### PR TITLE
Implement chestshop cooldown update

### DIFF
--- a/Itemex/src/main/java/sh/ome/itemex/Itemex.java
+++ b/Itemex/src/main/java/sh/ome/itemex/Itemex.java
@@ -3,8 +3,6 @@
 /* BUGS AND IMPROVEMENTS:
 
 # Important
-- chestshop: if two chests buy from each other -> missing items! Need cooldown if chestorder is created
-
 # Nice to have #
 - /ix market order -> confirm also at GUI (right calculation)
 - add goat_horns, suspicious_stew, painting support, items with more than 1 enchantment

--- a/Itemex/src/main/java/sh/ome/itemex/functions/sqliteDb.java
+++ b/Itemex/src/main/java/sh/ome/itemex/functions/sqliteDb.java
@@ -870,6 +870,8 @@ public class sqliteDb {
         PreparedStatement pstmt = null;
         int update_status = 0;
         String sql;
+        boolean chestOrder = ordertype.contains("chest") || price <= 0;
+        long now = Instant.now().getEpochSecond();
 
         if(ordertype.contains("admin")) {
             return true;
@@ -882,20 +884,38 @@ public class sqliteDb {
 
         if (Itemex.c != null) {
             try {
-                if(price > 0)
-                    sql = "UPDATE " + table_name + " SET ordertype = ?, amount = ?, price = ? WHERE id = ?";
-                else // chest shop
-                    sql = "UPDATE " + table_name + " SET amount = ? WHERE id = ?";
+                if(price > 0) {
+                    if(chestOrder)
+                        sql = "UPDATE " + table_name + " SET ordertype = ?, amount = ?, price = ?, timestamp = ? WHERE id = ?";
+                    else
+                        sql = "UPDATE " + table_name + " SET ordertype = ?, amount = ?, price = ? WHERE id = ?";
+                }
+                else { // chest shop
+                    if(chestOrder)
+                        sql = "UPDATE " + table_name + " SET amount = ?, timestamp = ? WHERE id = ?";
+                    else
+                        sql = "UPDATE " + table_name + " SET amount = ? WHERE id = ?";
+                }
 
                 pstmt = Itemex.c.prepareStatement(sql);
                 if(price > 0) {
                     pstmt.setString(1, ordertype);
                     pstmt.setInt(2, amount);
                     pstmt.setDouble(3, price);
-                    pstmt.setInt(4, ID);
+                    if(chestOrder) {
+                        pstmt.setLong(4, now);
+                        pstmt.setInt(5, ID);
+                    } else {
+                        pstmt.setInt(4, ID);
+                    }
                 } else {
                     pstmt.setInt(1, amount);
-                    pstmt.setInt(2, ID);
+                    if(chestOrder) {
+                        pstmt.setLong(2, now);
+                        pstmt.setInt(3, ID);
+                    } else {
+                        pstmt.setInt(2, ID);
+                    }
                 }
 
                 update_status = pstmt.executeUpdate();

--- a/changelog.txt
+++ b/changelog.txt
@@ -19,3 +19,6 @@
 ## [0.2.1] - Security and stability fixes
 - Sanitized table name and used prepared statements in `blockOrder` to prevent SQL injection.
 - Replaced default database password in `config.yml` with placeholder.
+
+## [0.2.2] - ChestShop cooldown improvements
+- Added timestamp updates on chest order modifications to prevent rapid trades between connected chests.


### PR DESCRIPTION
## Summary
- update order timestamps for ChestShop interactions
- remove todo entry about chestshop cooldown
- document change in changelog

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68548d83b85c832a838e9beef25a253f