### PR TITLE
Add basic unit tests

### DIFF
--- a/Itemex/pom.xml
+++ b/Itemex/pom.xml
@@ -89,6 +89,13 @@
       <version>2.7.3</version>  <!-- Use the latest version -->
     </dependency>
 
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+
 
   </dependencies>
 </project>

--- a/Itemex/src/test/java/sh/ome/itemex/CommandsTest.java
+++ b/Itemex/src/test/java/sh/ome/itemex/CommandsTest.java
@@ -1,0 +1,21 @@
+package sh.ome.itemex;
+
+import org.junit.Test;
+import sh.ome.itemex.commands.commands;
+
+import static org.junit.Assert.*;
+
+public class CommandsTest {
+    @Test
+    public void testGetItemId() {
+        String json = "[{\"itemid\":\"DIAMOND_SWORD\"}]";
+        assertEquals("DIAMOND_SWORD", commands.get_itemid(json));
+    }
+
+    @Test
+    public void testGetJsonFromMeta() {
+        String meta = "DIAMOND_SWORD";
+        String expected = "[{\"itemid\":\"DIAMOND_SWORD\"}]";
+        assertEquals(expected, commands.get_json_from_meta(meta));
+    }
+}

--- a/Itemex/src/test/java/sh/ome/itemex/SqliteDbTest.java
+++ b/Itemex/src/test/java/sh/ome/itemex/SqliteDbTest.java
@@ -1,0 +1,40 @@
+package sh.ome.itemex;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import sh.ome.itemex.functions.sqliteDb;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+
+import static org.junit.Assert.*;
+
+public class SqliteDbTest {
+    private Connection connection;
+
+    @Before
+    public void setup() throws Exception {
+        Class.forName("org.sqlite.JDBC");
+        connection = DriverManager.getConnection("jdbc:sqlite::memory:");
+        Statement stmt = connection.createStatement();
+        stmt.executeUpdate("CREATE TABLE PAYOUTS (id INTEGER PRIMARY KEY AUTOINCREMENT, player_uuid TEXT, itemid TEXT, amount INT, timestamp TEXT)");
+        stmt.close();
+        sh.ome.itemex.Itemex.c = connection;
+    }
+
+    @After
+    public void teardown() throws Exception {
+        connection.close();
+    }
+
+    @Test
+    public void testInsertAndGetPayout() {
+        assertTrue(sqliteDb.insertPayout("player", "DIAMOND", 5));
+        sqliteDb.Payout[] payouts = sqliteDb.getPayout("player");
+        assertEquals(1, payouts.length);
+        assertEquals("DIAMOND", payouts[0].itemid);
+        assertEquals(5, payouts[0].amount);
+    }
+}

--- a/Itemex/src/test/java/sh/ome/itemex/TopOrdersTest.java
+++ b/Itemex/src/test/java/sh/ome/itemex/TopOrdersTest.java
@@ -1,0 +1,21 @@
+package sh.ome.itemex;
+
+import org.junit.Test;
+import sh.ome.itemex.RAM.TopOrders;
+
+import static org.junit.Assert.*;
+
+public class TopOrdersTest {
+    @Test
+    public void testFindOrderMatch() {
+        TopOrders top = new TopOrders();
+        double[] buyPrices = {10,0,0,0,0};
+        double[] sellPrices = {8,0,0,0,0};
+        int[] buyAmounts = {1,0,0,0,0};
+        int[] sellAmounts = {1,0,0,0,0};
+        double[] lastPrices = {0,0,0,0,0};
+        int[] timestamps = {0,0,0,0,0};
+        top.update_topOrders("DIAMOND", buyPrices, sellPrices, buyAmounts, sellAmounts, lastPrices, timestamps);
+        assertTrue(top.find_order_match());
+    }
+}

--- a/changelog.txt
+++ b/changelog.txt
@@ -19,3 +19,6 @@
 ## [0.2.1] - Security and stability fixes
 - Sanitized table name and used prepared statements in `blockOrder` to prevent SQL injection.
 - Replaced default database password in `config.yml` with placeholder.
+
+## [0.2.2] - Added unit tests
+- Introduced JUnit tests for command parsing, order placement, and database operations.


### PR DESCRIPTION
## Summary
- add basic JUnit tests for command parsing, TopOrders logic and sqlite payout
- add JUnit dependency
- update changelog

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68548dab7a64832ab8fa75a85c02efa6